### PR TITLE
drop support for legacy REQUEST_PATH and use PATH_INFO instead

### DIFF
--- a/lib/escher/request/rack_request.rb
+++ b/lib/escher/request/rack_request.rb
@@ -15,16 +15,12 @@ class Escher::Request::RackRequest < Escher::Request::Base
     @rack_request
   end
 
-  def uri
-    @rack_request.env['REQUEST_URI']
-  end
-
   def path
-    @rack_request.env['REQUEST_PATH']
+    @rack_request.env[::Rack::PATH_INFO]
   end
 
   def host
-    @rack_request.env['HTTP_HOST']
+    @rack_request.env[::Rack::HTTP_HOST]
   end
 
   def headers

--- a/lib/escher/version.rb
+++ b/lib/escher/version.rb
@@ -1,3 +1,3 @@
 module Escher
-  VERSION = '0.4.2'
+  VERSION = '0.4.3'
 end

--- a/spec/escher/request/rack_request_spec.rb
+++ b/spec/escher/request/rack_request_spec.rb
@@ -5,7 +5,7 @@ require 'rack/request'
 
 describe Escher::Request::RackRequest do
 
-  let(:request_params) { {"PATH_INFO" => "/", } }
+  let(:request_params) { {Rack::PATH_INFO => "/", } }
   let(:request) { Rack::Request.new request_params }
 
   subject { described_class.new request }
@@ -88,7 +88,7 @@ describe Escher::Request::RackRequest do
 
   describe "#path" do
     it "should return the request path" do
-      request_params.merge! 'REQUEST_PATH' => '/resources/id///'
+      request_params[Rack::PATH_INFO]= '/resources/id///'
 
       expect(subject.path).to eq '/resources/id///'
     end


### PR DESCRIPTION
This will remove the bugs with rack request escher authentications on webservers that do not support REQUEST_PATH anymore or support in wrong way (constant value with "/") 