### PR TITLE
Bug fix: for credentials cope with trailing slash signing key calculation.

### DIFF
--- a/lib/escher/auth.rb
+++ b/lib/escher/auth.rb
@@ -199,7 +199,7 @@ module Escher
       string_to_sign = get_string_to_sign(canonicalized_request, current_time)
 
       signing_key = OpenSSL::HMAC.digest(@algo, @algo_prefix + api_secret, short_date(current_time))
-      @credential_scope.split('/').each { |data|
+      @credential_scope.split('/', -1).each { |data|
         signing_key = OpenSSL::HMAC.digest(@algo, signing_key, data)
       }
 


### PR DESCRIPTION
presumably bug fix, this makes it calculate the signing key the same way as js version does, given that credential_scope ends with the trailing slash like 'my/credentials/scope/', js version splits it into ['my', 'credentials', 'scope', ''], ruby without this splits it into ['my', 'credentials', 'scope'], all test passes, so in other words test case for this particular case wasn't ever there.